### PR TITLE
Add timeline parameter to config file example

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ commands: # Commands to run to processes automated actions in the app to be meas
     - make -C ../argos-realworld run-test
 
 out_dir: ./measures_directory # Local path to stored measures
+
+timeline: ./measures_directory/timeline.txt # Local path to timeline log
 ```
 
 After the execution, measures files will be available in JSON format at:


### PR DESCRIPTION
When trying to use the `argos-cli` tool on our application we ran into an error that after some searching had to do with the `timeline` key missing from the config file. I've updated the documentation to include this key.