### PR TITLE
Add windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,15 @@ Positionals:
   path                                                       [string] [required]
 
 Options:
-      --help      Show help                                            [boolean]
+      --help        Show help                                          [boolean]
   -r, --revision                                             [string] [required]
   -s, --samples                                            [number] [default: 1]
+  -m, --socketMode                                    [string] [default: "unix"]
 
 Examples:
-  ./bin/argos.sh run ./my_project.yml -r my_revision
-  ./bin/argos.sh run ./my_project.yml -r my_revision -s 2
+  argos run ./my_project.yml -r my_revision
+  argos run ./my_project.yml -r my_revision -t 2
+  argos run ./my_project.yml -r my_revision -t 2 -m windows
 ```
 
 **Configuration file .yml:**

--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ Options:
   -m, --socketMode                                    [string] [default: "unix"]
 
 Examples:
-  argos run ./my_project.yml -r my_revision
-  argos run ./my_project.yml -r my_revision -t 2
-  argos run ./my_project.yml -r my_revision -t 2 -m windows
+  ./bin/argos.sh run ./my_project.yml -r my_revision
+  ./bin/argos.sh run ./my_project.yml -r my_revision -t 2
+  ./bin/argos.sh run ./my_project.yml -r my_revision -t 2 -m windows
 ```
 
 **Configuration file .yml:**

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -14,7 +14,7 @@ export const run = async (args: {
     path: string;
     revision: string;
     samples: number;
-    socketMode: string;
+    socketMode: "unix" | "windows";
 }): Promise<void> => {
     const config = safeLoad<{
         project: string;

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -19,7 +19,7 @@ export const run = async (args: {
         out_dir: string;
         timeline: string;
     }>(fs.readFileSync(args.path, "utf8"));
-
+    console.log(args.socketPath);
     fs.lstatSync(config.out_dir).isDirectory();
     for (const preCommand of config.pre_commands) {
         console.log(preCommand);

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -9,6 +9,7 @@ export const run = async (args: {
     path: string;
     revision: string;
     samples: number;
+    socketPath: string;
 }): Promise<void> => {
     const config = safeLoad<{
         project: string;
@@ -39,7 +40,7 @@ export const run = async (args: {
         const stats: Array<{ container: string; stats: string }> = [];
         // spawn the processes before the dockers commands are executed
         const childProcesses = config.containers.map((container) => {
-            return gatherStats(container, (statsStringify) => {
+            return gatherStats(container, args.socketPath, (statsStringify) => {
                 stats.push({ container, stats: statsStringify });
             });
         });

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -5,16 +5,16 @@ import * as async from "../async";
 import { gatherStats } from "../gatherStats";
 import type { IntervalJSON } from "../types";
 
-enum SocketModeEnum {
-    Windows = "//./pipe/docker_engine",
-    Unix = "/var/run/docker.sock",
-}
+const socketMode = {
+    windows: "//./pipe/docker_engine",
+    unix: "/var/run/docker.sock",
+} as const;
 
 export const run = async (args: {
     path: string;
     revision: string;
     samples: number;
-    socketMode: "unix" | "windows";
+    socketMode: keyof typeof socketMode;
 }): Promise<void> => {
     const config = safeLoad<{
         project: string;
@@ -26,8 +26,7 @@ export const run = async (args: {
     }>(fs.readFileSync(args.path, "utf8"));
     fs.lstatSync(config.out_dir).isDirectory();
 
-    const socketPath =
-        args.socketMode === "windows" ? SocketModeEnum.Windows : SocketModeEnum.Unix;
+    const socketPath = socketMode[args.socketMode];
 
     for (const preCommand of config.pre_commands) {
         const result = await async.exec(preCommand);

--- a/src/gatherStats.ts
+++ b/src/gatherStats.ts
@@ -2,18 +2,18 @@ import * as child_process from "child_process";
 
 export const gatherStats = (
     container: string,
+    socketPath: string,
     callback: (stats: string) => void,
-): child_process.ChildProcessWithoutNullStreams => {
-    const childProcess = child_process.spawn("curl", [
-        "--unix-socket",
-        "/var/run/docker.sock",
-        `http://localhost/containers/${container}/stats`,
+): child_process.ChildProcess => {
+    const childProcess = child_process.fork("getStatOfContainer.ts", [
+        socketPath,
+        `/containers/${container}/stats`,
     ]);
     const buffers: Buffer[] = [];
-
-    childProcess.stdout.on("data", (buffer) => {
+    childProcess.stdout?.on("data", (buffer) => {
         buffers.push(buffer);
     });
+
     childProcess.on("close", () => {
         console.log(`close ${container}:`, new Date());
         const lines: string[] = buffers

--- a/src/gatherStats.ts
+++ b/src/gatherStats.ts
@@ -1,17 +1,20 @@
 import * as child_process from "child_process";
+import * as path from "path";
 
 export const gatherStats = (
     container: string,
     socketPath: string,
     callback: (stats: string) => void,
 ): child_process.ChildProcess => {
-    const childProcess = child_process.fork("getStatOfContainer.ts", [
+    const childProcess = child_process.fork(path.resolve(__dirname, "./getStatOfContainer"), [
         socketPath,
         `/containers/${container}/stats`,
     ]);
     const buffers: Buffer[] = [];
-    childProcess.stdout?.on("data", (buffer) => {
-        buffers.push(buffer);
+    childProcess.on("message", (res: {
+        data: []
+    }) => {
+        buffers.push(Buffer.from(res.data));
     });
 
     childProcess.on("close", () => {

--- a/src/getStatOfContainer.ts
+++ b/src/getStatOfContainer.ts
@@ -7,7 +7,11 @@ const options = {
 };
 
 const callback = (res: http.IncomingMessage) => {
-    res.on("data", (data) => console.log(data));
+    res.on("data", (data: Buffer) => {
+        if (process.send) {
+            process.send(data);
+        }
+    });
 };
 
 const clientRequest = http.request(options, callback);

--- a/src/getStatOfContainer.ts
+++ b/src/getStatOfContainer.ts
@@ -1,0 +1,14 @@
+import * as http from "http";
+
+const options = {
+    socketPath: process.argv[2],
+    path: process.argv[3],
+    method: "GET",
+};
+
+const callback = (res: http.IncomingMessage) => {
+    res.on("data", (data) => console.log(data));
+};
+
+const clientRequest = http.request(options, callback);
+clientRequest.end();

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,18 +23,15 @@ yargs(process.argv.slice(2))
                     default: 1,
                     type: "number",
                 })
-                .option("socketPath", {
-                    alias: "so",
-                    default: "/var/run/docker.sock",
+                .option("socketMode", {
+                    alias: "m",
+                    default: "unix",
                     type: "string",
                 })
                 .example([
                     ["$0 run ./my_project.yml -r my_revision", ""],
                     ["$0 run ./my_project.yml -r my_revision -t 2", ""],
-                    [
-                        "$0 run ./my_project.yml -r my_revision -t 2 -so //./pipe/docker_engine",
-                        "",
-                    ],
+                    ["$0 run ./my_project.yml -r my_revision -t 2 -m windows", ""],
                 ]);
         },
         run,

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,9 +23,18 @@ yargs(process.argv.slice(2))
                     default: 1,
                     type: "number",
                 })
+                .option("socketPath", {
+                    alias: "so",
+                    default: "/var/run/docker.sock",
+                    type: "string",
+                })
                 .example([
                     ["$0 run ./my_project.yml -r my_revision", ""],
                     ["$0 run ./my_project.yml -r my_revision -t 2", ""],
+                    [
+                        "$0 run ./my_project.yml -r my_revision -t 2 -so //./pipe/docker_engine",
+                        "",
+                    ],
                 ]);
         },
         run,


### PR DESCRIPTION
- [x] Remove usage of curl command because curl is not supported by default on windows.
- [x] Add new params during `run` command : socketMode (-m) to define which kind of socket to use.
- [x] use node script with http module to query docker remote engine API.
- [x] Replace `child_process.spawn` by `child_process.fork` which allow us to execute node child_process.  
- [x] Explain this new param in readme.
- [x] Test this on a real Linux
- [x] Test this on a real windows
